### PR TITLE
fix: fix generate_boolean_function format error

### DIFF
--- a/kong/plugins/advanced-router/handler.lua
+++ b/kong/plugins/advanced-router/handler.lua
@@ -68,7 +68,7 @@ function set_upstream(upstream_url)
     local port = tonumber(parsed_url['port']) or 80
     local scheme = parsed_url['scheme'] or 'http'
     local path = parsed_url['path']
-    debug("Setting upstream values::")
+    debug("Setting below upstream values")
     debug("Host::" .. host)
     debug("Port::" .. port)
     debug("Path::" .. path)

--- a/kong/plugins/advanced-router/handler.lua
+++ b/kong/plugins/advanced-router/handler.lua
@@ -64,11 +64,19 @@ end
 
 function set_upstream(upstream_url)
     local parsed_url = url.parse(upstream_url)
-    debug("Setting upstream URL::" .. upstream_url)
-    kong.service.request.set_scheme(parsed_url['scheme'] or 'http')
-    kong.service.set_target(parsed_url['host'], tonumber(parsed_url['port']) or 80)
+    local host = parsed_url['host']
+    local port = tonumber(parsed_url['port']) or 80
+    local scheme = parsed_url['scheme'] or 'http'
+    local path = parsed_url['path']
+    debug("Setting upstream values::")
+    debug("Host::" .. host)
+    debug("Port::" .. port)
+    debug("Path::" .. path)
+    debug("Protocol::" .. scheme)
+    kong.service.request.set_scheme(scheme)
+    kong.service.set_target(host, port)
     if parsed_url['path'] then
-        kong.service.request.set_path(parsed_url['path'])
+        kong.service.request.set_path(path)
     end
 end
 

--- a/kong/plugins/advanced-router/handler.lua
+++ b/kong/plugins/advanced-router/handler.lua
@@ -5,9 +5,9 @@ local date = require "date"
 local pl_utils = require "pl.utils"
 
 local kong = kong
+local debug = kong.log.debug
 
 local get_io_data = require("kong.plugins.advanced-router.io").get_io_data
-local extract = require("kong.plugins.advanced-router.utils").extract
 local interpolate_string_env = require("kong.plugins.advanced-router.utils").interpolate_string_env
 
 local AdvancedRouterHandler = {}
@@ -34,7 +34,7 @@ function generate_boolean_function(proposition)
         return assert(loadstring("return " .. "\"" .. proposition["upstream_url"] .. "\""))
     end
     local upstream_url = proposition["upstream_url"]
-    return assert(loadstring("if " .. proposition["condition"] .. "then return " .. "\"" .. upstream_url .. "\"" .. " end"))
+    return assert(loadstring("if " .. proposition["condition"] .. " then return " .. "\"" .. upstream_url .. "\"" .. " end"))
 end
 
 function get_upstream_url(conf)
@@ -64,6 +64,7 @@ end
 
 function set_upstream(upstream_url)
     local parsed_url = url.parse(upstream_url)
+    debug("Setting upstream URL::" .. upstream_url)
     kong.service.request.set_scheme(parsed_url['scheme'] or 'http')
     kong.service.set_target(parsed_url['host'], tonumber(parsed_url['port']) or 80)
     if parsed_url['path'] then

--- a/spec/advanced-router/01-access_spec.lua
+++ b/spec/advanced-router/01-access_spec.lua
@@ -341,6 +341,36 @@ for _, strategy in helpers.each_strategy() do
             end)
 
         end)
+
+        describe("Should work for conditions ending in integer literal #integer_literal", function()
+
+            lazy_setup(function()
+                local propositions_json = {
+                    { condition = "extract_from_io_response('data.service_host') == 1", upstream_url = "http://" .. service_one_host .. service_one_route },
+                    { condition = "default", upstream_url = "http://" .. service_default_host .. service_default_route },
+                }
+
+                local io_request_template = {
+                    headers = {
+                        ['service_host'] = "headers.service_host"
+                    }
+                }
+                setup_db(propositions_json, io_request_template, service_io_call_host, { "data.service_host" }, "headers.service_host")
+            end)
+
+            teardown(function()
+                helpers.stop_kong()
+                db:truncate()
+            end)
+
+            it("Should return 200 response", function()
+                local req_data = { headers = { service_host = 1} }
+                local expected_resp = { host = service_default_host, uri = service_default_route, scheme = 'http' }
+                get_and_assert_upstream(req_data, expected_resp)
+            end)
+
+        end)
+
     end)
     break
 end


### PR DESCRIPTION
### Summary

This change fixes an error that is generated when creating boolean functions using `loadstring` function when the condition string ends in an integer as there is no space separator between condition string and `then` keyword.

Added test case for condition ending in integer literal